### PR TITLE
Fix positioning of users logos in docs

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -676,3 +676,7 @@ div.sphinx-feature > p.admonition-title::before {
     justify-content: center;
     gap: 10px;
 }
+
+.sphinx-users-logos .headerlink {
+    display: none;
+}


### PR DESCRIPTION
The texts under the logos were not centered in https://www.sphinx-doc.org/en/master/ because there's a hidden header link target form the `.. figure::` directive.

![image](https://github.com/timhoffm/sphinx/assets/2836374/ca334206-bda1-4f8b-8ccf-13bd4559e4fd)

Since `..figure::` always creates this but we don't need it, the most simple fix is to hide it via CSS.
